### PR TITLE
feat: Add Anthropic as native provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,13 @@ dependencies = [
     "httpx>=0.28.1",
     "sentry-sdk[fastapi]>=2.48.0",
     "google-auth>=2.45.0",
+    "anthropic>=0.72.0",
 ]
 
 [project.optional-dependencies]
+anthropic = [
+    "anthropic>=0.40.0",
+]
 dev = [
     "pytest>=6.0",
     "pytest-asyncio>=0.21.0",

--- a/src/elelem/_anthropic_adapter.py
+++ b/src/elelem/_anthropic_adapter.py
@@ -1,0 +1,409 @@
+"""
+Anthropic API adapter for Elelem.
+
+Duck-type compatible with openai.AsyncOpenAI — translates between
+Anthropic Messages API and OpenAI Chat Completions format so that
+Elelem's request handlers and response processing work unchanged.
+"""
+
+import time
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger("elelem.anthropic_adapter")
+
+# ---------------------------------------------------------------------------
+# Stop-reason mapping: Anthropic → OpenAI
+# ---------------------------------------------------------------------------
+_STOP_REASON_MAP = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "tool_use": "tool_calls",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_response(status_code: int) -> httpx.Response:
+    """Create a minimal httpx.Response for OpenAI exception constructors."""
+    return httpx.Response(
+        status_code=status_code,
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+
+
+def _translate_messages(messages: List[Dict]) -> tuple:
+    """Extract system messages and convert to Anthropic format.
+
+    Returns:
+        (system_text or None, anthropic_messages)
+    """
+    system_parts = []
+    anthropic_messages = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+
+        if role == "system":
+            if isinstance(content, str):
+                system_parts.append(content)
+            elif isinstance(content, list):
+                # Handle structured content parts
+                for part in content:
+                    if isinstance(part, dict) and "text" in part:
+                        system_parts.append(part["text"])
+                    elif isinstance(part, str):
+                        system_parts.append(part)
+        else:
+            anthropic_messages.append({"role": role, "content": content})
+
+    system_text = "\n\n".join(system_parts) if system_parts else None
+    return system_text, anthropic_messages
+
+
+def _translate_kwargs(kwargs: Dict) -> Dict:
+    """Translate OpenAI-style kwargs to Anthropic parameters.
+
+    Modifies kwargs in-place (pops consumed keys) and returns Anthropic kwargs.
+    """
+    anthropic_kwargs = {}
+
+    # max_tokens is required by Anthropic
+    anthropic_kwargs["max_tokens"] = kwargs.pop("max_tokens", 4096)
+
+    # Pass through supported params
+    if "temperature" in kwargs:
+        anthropic_kwargs["temperature"] = kwargs.pop("temperature")
+
+    if "stream" in kwargs:
+        anthropic_kwargs["stream"] = kwargs.pop("stream")
+
+    if "top_p" in kwargs:
+        if "temperature" not in anthropic_kwargs:
+            anthropic_kwargs["top_p"] = kwargs.pop("top_p")
+        else:
+            kwargs.pop("top_p")  # Anthropic forbids both temperature and top_p
+
+    if "stop" in kwargs:
+        anthropic_kwargs["stop_sequences"] = kwargs.pop("stop")
+
+    # Handle extra_body — merge into top-level (for thinking config etc.)
+    extra_body = kwargs.pop("extra_body", None)
+    if extra_body and isinstance(extra_body, dict):
+        anthropic_kwargs.update(extra_body)
+
+    # Drop unsupported OpenAI-specific params silently
+    for key in [
+        "response_format", "reasoning_effort", "service_tier",
+        "stream_options", "n", "frequency_penalty",
+        "presence_penalty", "logprobs", "top_logprobs",
+        "seed", "logit_bias", "user", "tools", "tool_choice",
+    ]:
+        kwargs.pop(key, None)
+
+    # Warn about remaining unknown kwargs
+    if kwargs:
+        logger.debug(f"Dropping unknown kwargs for Anthropic: {list(kwargs.keys())}")
+
+    return anthropic_kwargs
+
+
+def _translate_response(anthropic_response) -> Any:
+    """Translate Anthropic Message → OpenAI ChatCompletion."""
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+    from openai.types.chat.chat_completion import ChatCompletion, Choice
+    from openai.types.completion_usage import CompletionUsage
+
+    # Extract text and thinking content from content blocks
+    text_parts = []
+    thinking_parts = []
+
+    for block in anthropic_response.content:
+        if block.type == "text":
+            text_parts.append(block.text)
+        elif block.type == "thinking":
+            thinking_parts.append(block.thinking)
+
+    content = "".join(text_parts) if text_parts else None
+    reasoning_content = "".join(thinking_parts) if thinking_parts else None
+
+    finish_reason = _STOP_REASON_MAP.get(anthropic_response.stop_reason, "stop")
+
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=content,
+        reasoning_content=reasoning_content,
+    )
+
+    choice = Choice(index=0, message=message, finish_reason=finish_reason)
+
+    usage = CompletionUsage(
+        prompt_tokens=anthropic_response.usage.input_tokens,
+        completion_tokens=anthropic_response.usage.output_tokens,
+        total_tokens=(
+            anthropic_response.usage.input_tokens
+            + anthropic_response.usage.output_tokens
+        ),
+    )
+
+    return ChatCompletion(
+        id=anthropic_response.id,
+        object="chat.completion",
+        created=int(time.time()),
+        model=anthropic_response.model,
+        choices=[choice],
+        usage=usage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming translator — async generator yielding ChatCompletionChunk
+# ---------------------------------------------------------------------------
+
+class _StreamAdapter:
+    """Async iterable that yields OpenAI ChatCompletionChunk from Anthropic stream."""
+
+    def __init__(self, anthropic_stream):
+        self._stream = anthropic_stream
+        self._message_id: Optional[str] = None
+        self._model: Optional[str] = None
+        self._input_tokens: int = 0
+
+    def __aiter__(self):
+        return self._translate()
+
+    async def _translate(self):
+        from openai.types.chat.chat_completion_chunk import (
+            ChatCompletionChunk,
+            Choice as ChunkChoice,
+            ChoiceDelta,
+        )
+        from openai.types.completion_usage import CompletionUsage
+
+        async for event in self._stream:
+            event_type = event.type
+
+            if event_type == "message_start":
+                self._message_id = event.message.id
+                self._model = event.message.model
+                self._input_tokens = event.message.usage.input_tokens
+                # Yield initial empty chunk (sets up id/model for collector)
+                yield ChatCompletionChunk(
+                    id=self._message_id,
+                    object="chat.completion.chunk",
+                    created=int(time.time()),
+                    model=self._model,
+                    choices=[ChunkChoice(
+                        index=0,
+                        delta=ChoiceDelta(role="assistant"),
+                        finish_reason=None,
+                    )],
+                )
+
+            elif event_type == "content_block_delta":
+                delta_type = event.delta.type
+
+                if delta_type == "text_delta":
+                    yield ChatCompletionChunk(
+                        id=self._message_id or "",
+                        object="chat.completion.chunk",
+                        created=int(time.time()),
+                        model=self._model or "",
+                        choices=[ChunkChoice(
+                            index=0,
+                            delta=ChoiceDelta(content=event.delta.text),
+                            finish_reason=None,
+                        )],
+                    )
+
+                elif delta_type == "thinking_delta":
+                    # Map to reasoning field (same as OpenRouter convention)
+                    delta = ChoiceDelta(content=None)
+                    # Set reasoning via attribute since it may not be
+                    # in the constructor for all openai SDK versions
+                    delta.reasoning = event.delta.thinking
+                    yield ChatCompletionChunk(
+                        id=self._message_id or "",
+                        object="chat.completion.chunk",
+                        created=int(time.time()),
+                        model=self._model or "",
+                        choices=[ChunkChoice(
+                            index=0,
+                            delta=delta,
+                            finish_reason=None,
+                        )],
+                    )
+
+                # Skip signature_delta, input_json_delta, etc.
+
+            elif event_type == "message_delta":
+                # Final chunk with stop_reason and usage
+                finish_reason = _STOP_REASON_MAP.get(
+                    event.delta.stop_reason, "stop"
+                )
+                output_tokens = event.usage.output_tokens
+
+                usage = CompletionUsage(
+                    prompt_tokens=self._input_tokens,
+                    completion_tokens=output_tokens,
+                    total_tokens=self._input_tokens + output_tokens,
+                )
+
+                yield ChatCompletionChunk(
+                    id=self._message_id or "",
+                    object="chat.completion.chunk",
+                    created=int(time.time()),
+                    model=self._model or "",
+                    choices=[ChunkChoice(
+                        index=0,
+                        delta=ChoiceDelta(),
+                        finish_reason=finish_reason,
+                    )],
+                    usage=usage,
+                )
+
+            # Skip: content_block_start, content_block_stop,
+            #        message_stop, ping
+
+
+# ---------------------------------------------------------------------------
+# Error translation
+# ---------------------------------------------------------------------------
+
+def _translate_error(error: Exception) -> Exception:
+    """Translate Anthropic SDK exception → OpenAI SDK exception."""
+    from openai import (
+        AuthenticationError as OAIAuthError,
+        RateLimitError as OAIRateLimitError,
+        BadRequestError as OAIBadRequestError,
+        NotFoundError as OAINotFoundError,
+        InternalServerError as OAIInternalServerError,
+        APIConnectionError as OAIConnectionError,
+    )
+
+    # Lazy import to avoid top-level dependency
+    import anthropic as anth
+
+    status_code = getattr(error, "status_code", 500)
+    msg = str(error)
+    body = getattr(error, "body", None)
+    resp = _mock_response(status_code)
+
+    if isinstance(error, anth.AuthenticationError):
+        return OAIAuthError(msg, response=resp, body=body)
+
+    if isinstance(error, anth.RateLimitError):
+        return OAIRateLimitError(msg, response=resp, body=body)
+
+    if isinstance(error, anth.BadRequestError):
+        return OAIBadRequestError(msg, response=resp, body=body)
+
+    if isinstance(error, anth.NotFoundError):
+        return OAINotFoundError(msg, response=resp, body=body)
+
+    if isinstance(error, anth.InternalServerError):
+        return OAIInternalServerError(msg, response=resp, body=body)
+
+    if isinstance(error, anth.APIConnectionError):
+        return OAIConnectionError(request=resp.request)
+
+    if isinstance(error, anth.APIStatusError):
+        return OAIInternalServerError(msg, response=resp, body=body)
+
+    # Not an Anthropic SDK error — re-raise as-is
+    return error
+
+
+# ---------------------------------------------------------------------------
+# Adapter classes — duck-type compatible with AsyncOpenAI
+# ---------------------------------------------------------------------------
+
+class _Completions:
+    """Duck-type compatible with openai.AsyncOpenAI().chat.completions."""
+
+    def __init__(self, adapter: "AnthropicAdapter"):
+        self._adapter = adapter
+        self._client = None
+
+    def _get_client(self):
+        """Lazy-init the Anthropic async client."""
+        if self._client is None:
+            try:
+                import anthropic
+            except ImportError:
+                raise ImportError(
+                    "The 'anthropic' package is required for Anthropic providers. "
+                    "Install it with: uv add anthropic"
+                )
+            self._client = anthropic.AsyncAnthropic(
+                api_key=self._adapter.api_key,
+            )
+
+        # Propagate api_key changes (token refresh pattern from core.py:679)
+        if self._client.api_key != self._adapter.api_key:
+            self._client.api_key = self._adapter.api_key
+
+        return self._client
+
+    async def create(self, *, messages, model, **kwargs):
+        """Translate and execute an Anthropic Messages API call.
+
+        Accepts OpenAI-style parameters, translates to Anthropic format,
+        and returns OpenAI-compatible response objects.
+        """
+        client = self._get_client()
+
+        # Translate messages (extract system → top-level param)
+        system_text, anthropic_messages = _translate_messages(messages)
+
+        # Translate parameters
+        is_streaming = kwargs.get("stream", False)
+        anthropic_kwargs = _translate_kwargs(kwargs)
+        anthropic_kwargs["model"] = model
+        anthropic_kwargs["messages"] = anthropic_messages
+
+        if system_text:
+            anthropic_kwargs["system"] = system_text
+
+        try:
+            if is_streaming:
+                stream = await client.messages.create(**anthropic_kwargs)
+                return _StreamAdapter(stream)
+            else:
+                response = await client.messages.create(**anthropic_kwargs)
+                return _translate_response(response)
+
+        except Exception as e:
+            # Translate Anthropic errors to OpenAI errors
+            translated = _translate_error(e)
+            if translated is not e:
+                raise translated from e
+            raise
+
+
+class _Chat:
+    """Duck-type compatible with openai.AsyncOpenAI().chat."""
+
+    def __init__(self, completions: _Completions):
+        self.completions = completions
+
+
+class AnthropicAdapter:
+    """Duck-type compatible with openai.AsyncOpenAI.
+
+    Usage by Elelem internals:
+        client = AnthropicAdapter(api_key="sk-...")
+        client.chat.completions.create(messages=..., model=..., **kwargs)
+        client.api_key = new_key  # token refresh
+    """
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        completions = _Completions(self)
+        self.chat = _Chat(completions)

--- a/src/elelem/_benchmark_store.py
+++ b/src/elelem/_benchmark_store.py
@@ -166,7 +166,7 @@ def reorder_candidates_by_benchmark(
 
         # Get cost from candidate's model config (YAML) - always authoritative
         model_cost = candidate.get('cost', {})
-        cost_per_1m = model_cost.get('output_cost_per_1m', 0)
+        cost_per_1m = model_cost.get('output_cost_per_1m', 0) if isinstance(model_cost, dict) else 0
 
         # Get dynamic stats (observed tokens/s from recent requests)
         tps = None

--- a/src/elelem/_provider_management.py
+++ b/src/elelem/_provider_management.py
@@ -170,8 +170,17 @@ def validate_provider_models(provider_name: str, endpoint: str, api_key: Optiona
 
 
 def create_provider_client(api_key: str, base_url: str, timeout: int,
-                          provider_name: str, default_headers: Dict) -> openai.AsyncOpenAI:
-    """Create an OpenAI-compatible client for any provider."""
+                          provider_name: str, default_headers: Dict,
+                          client_type: str = None):
+    """Create an API client for any provider.
+
+    For OpenAI-compatible providers, returns AsyncOpenAI.
+    For Anthropic, returns an AnthropicAdapter (duck-type compatible).
+    """
+    if client_type == "anthropic":
+        from ._anthropic_adapter import AnthropicAdapter
+        return AnthropicAdapter(api_key=api_key)
+
     client_kwargs = {
         "api_key": api_key,
         "base_url": base_url,

--- a/src/elelem/_token_providers.py
+++ b/src/elelem/_token_providers.py
@@ -86,6 +86,30 @@ class StaticKeyProvider(TokenProvider):
         return self._api_key
 
 
+class AnthropicTokenProvider(TokenProvider):
+    """Token provider for Anthropic's Messages API."""
+
+    def __init__(self, provider_name: str, provider_config: Dict, logger: logging.Logger):
+        env_var = "ANTHROPIC_API_KEY"
+        self._api_key = os.getenv(env_var)
+        if not self._api_key:
+            raise ValueError(f"No API key found (env var: {env_var})")
+
+        self._provider_name = provider_name
+        logger.debug(f"[{provider_name}] Loaded API key from {env_var}")
+
+    def get_token(self) -> str:
+        return self._api_key
+
+    def get_endpoint(self) -> str:
+        return "https://api.anthropic.com"
+
+    def probe(self, endpoint: str, timeout: float, logger: logging.Logger) -> ProbeResult:
+        # Anthropic has no /models endpoint — skip probe (same as Vertex)
+        logger.debug(f"[{self._provider_name}] Skipping probe (Anthropic provider)")
+        return ProbeResult(success=True)
+
+
 class GoogleVertexProvider(TokenProvider):
     """Token provider for Google Vertex AI with auto-refresh."""
 
@@ -149,6 +173,7 @@ class GoogleVertexProvider(TokenProvider):
 
 # Registry of cloud token providers (require auth_type in config)
 CLOUD_PROVIDERS: Dict[str, Type[TokenProvider]] = {
+    "anthropic": AnthropicTokenProvider,
     "google_vertex": GoogleVertexProvider,
     # Future: "aws_bedrock": AWSBedrockProvider,
     # Future: "azure_openai": AzureOpenAIProvider,

--- a/src/elelem/core.py
+++ b/src/elelem/core.py
@@ -187,12 +187,14 @@ class Elelem:
 
         # Create provider client
         custom_headers = provider_config.get("headers")
+        client_type = provider_config.get("client_type")
         self._providers[provider_name] = create_provider_client(
             api_key=api_key,
             base_url=endpoint,
             timeout=self.config.timeout_seconds,
             provider_name=provider_name,
-            default_headers=custom_headers
+            default_headers=custom_headers,
+            client_type=client_type
         )
         self.logger.debug(f"[{provider_name}] Initialized successfully")
         return True

--- a/src/elelem/providers/_metadata.yaml
+++ b/src/elelem/providers/_metadata.yaml
@@ -147,11 +147,46 @@ model_metadata:
     model_nickname: "qwen3-30b-a3b"
     model_page: "https://huggingface.co/Qwen/Qwen3-30B-A3B"
     license: "Qwen License"
-    reasoning: "no"    
+    reasoning: "no"
+
+  alibaba_qwen35_plus: &alibaba-qwen35-plus
+    model_owner: "Alibaba"
+    model_nickname: "qwen3.5-plus"
+    model_page: "https://huggingface.co/Qwen"
+    license: "Qwen License"
+    reasoning: "no"
+
+  anthropic_claude_opus_46: &anthropic-claude-opus-46
+    model_owner: "Anthropic"
+    model_nickname: "claude-opus-4.6"
+    model_page: "https://www.anthropic.com/claude"
+    license: "Proprietary"
+    reasoning: "no"
+
+  anthropic_claude_sonnet_46: &anthropic-claude-sonnet-46
+    model_owner: "Anthropic"
+    model_nickname: "claude-sonnet-4.6"
+    model_page: "https://www.anthropic.com/claude"
+    license: "Proprietary"
+    reasoning: "no"
+
+  anthropic_claude_haiku_45: &anthropic-claude-haiku-45
+    model_owner: "Anthropic"
+    model_nickname: "claude-haiku-4.5"
+    model_page: "https://www.anthropic.com/claude"
+    license: "Proprietary"
+    reasoning: "no"
 
   anthropic_claude_sonnet_4: &anthropic-claude-sonnet-4
     model_owner: "Anthropic"
     model_nickname: "claude-sonnet-4"
+    model_page: "https://www.anthropic.com/claude"
+    license: "Proprietary"
+    reasoning: "no"
+
+  anthropic_claude_opus_4: &anthropic-claude-opus-4
+    model_owner: "Anthropic"
+    model_nickname: "claude-opus-4"
     model_page: "https://www.anthropic.com/claude"
     license: "Proprietary"
     reasoning: "no"

--- a/src/elelem/providers/anthropic.yaml
+++ b/src/elelem/providers/anthropic.yaml
@@ -1,0 +1,129 @@
+# Anthropic provider configuration and models
+# Uses ANTHROPIC_API_KEY env var for authentication
+# Anthropic API is NOT OpenAI-compatible — uses adapter (client_type: anthropic)
+
+provider:
+  auth_type: anthropic
+  client_type: anthropic
+  default_params:
+    stream: true
+  max_tokens_default: 16384
+
+models:
+  # ---------------------------------------------------------------------------
+  # Current generation
+  # ---------------------------------------------------------------------------
+
+  # Claude Opus 4.6 - most intelligent, best for agents and coding
+  "anthropic:anthropic/claude-opus-4.6":
+    metadata:
+      model_reference: "anthropic_claude_opus_46"
+    provider: anthropic
+    model_id: claude-opus-4-6
+    timeout: 300
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost:
+      input_cost_per_1m: 5.00
+      output_cost_per_1m: 25.00
+      currency: USD
+
+  # Claude Opus 4.6 with adaptive thinking
+  "anthropic:anthropic/claude-opus-4.6?thinking":
+    metadata:
+      model_reference: "anthropic_claude_opus_46"
+      model_configuration: "thinking"
+    provider: anthropic
+    model_id: claude-opus-4-6
+    timeout: 300
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost:
+      input_cost_per_1m: 5.00
+      output_cost_per_1m: 25.00
+      currency: USD
+    default_params:
+      max_tokens: 16000
+      extra_body:
+        thinking:
+          type: adaptive
+
+  # Claude Sonnet 4.6 - best speed/intelligence balance
+  "anthropic:anthropic/claude-sonnet-4.6":
+    metadata:
+      model_reference: "anthropic_claude_sonnet_46"
+    provider: anthropic
+    model_id: claude-sonnet-4-6
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost:
+      input_cost_per_1m: 3.00
+      output_cost_per_1m: 15.00
+      currency: USD
+
+  # Claude Sonnet 4.6 with extended thinking
+  "anthropic:anthropic/claude-sonnet-4.6?thinking":
+    metadata:
+      model_reference: "anthropic_claude_sonnet_46"
+      model_configuration: "thinking"
+    provider: anthropic
+    model_id: claude-sonnet-4-6
+    timeout: 300
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost:
+      input_cost_per_1m: 3.00
+      output_cost_per_1m: 15.00
+      currency: USD
+    default_params:
+      max_tokens: 16000
+      extra_body:
+        thinking:
+          type: enabled
+          budget_tokens: 10000
+
+  # Claude Haiku 4.5 - fastest, near-frontier intelligence
+  "anthropic:anthropic/claude-haiku-4.5":
+    metadata:
+      model_reference: "anthropic_claude_haiku_45"
+    provider: anthropic
+    model_id: claude-haiku-4-5-20251001
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost:
+      input_cost_per_1m: 1.00
+      output_cost_per_1m: 5.00
+      currency: USD
+
+  # Claude Haiku 4.5 with extended thinking
+  "anthropic:anthropic/claude-haiku-4.5?thinking":
+    metadata:
+      model_reference: "anthropic_claude_haiku_45"
+      model_configuration: "thinking"
+    provider: anthropic
+    model_id: claude-haiku-4-5-20251001
+    timeout: 300
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost:
+      input_cost_per_1m: 1.00
+      output_cost_per_1m: 5.00
+      currency: USD
+    default_params:
+      max_tokens: 16000
+      extra_body:
+        thinking:
+          type: enabled
+          budget_tokens: 10000

--- a/src/elelem/providers/openrouter.yaml
+++ b/src/elelem/providers/openrouter.yaml
@@ -4,7 +4,8 @@ provider:
   headers:
     HTTP-Referer: https://github.com/guybrush1984/Elelem
     X-Title: Elelem
-  default_params: {}
+  default_params:
+    stream: true
   extra_body:
     usage:
       include: true
@@ -50,6 +51,51 @@ models:
       model_reference: "anthropic_claude_sonnet_4"
     provider: openrouter
     model_id: anthropic/claude-sonnet-4
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost: runtime
+
+  "openrouter:anthropic/claude-opus-4.6":
+    metadata:
+      model_reference: "anthropic_claude_opus_46"
+    provider: openrouter
+    model_id: anthropic/claude-opus-4.6
+    timeout: 300
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost: runtime
+
+  "openrouter:anthropic/claude-sonnet-4.6":
+    metadata:
+      model_reference: "anthropic_claude_sonnet_46"
+    provider: openrouter
+    model_id: anthropic/claude-sonnet-4.6
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost: runtime
+
+  "openrouter:anthropic/claude-haiku-4.5":
+    metadata:
+      model_reference: "anthropic_claude_haiku_45"
+    provider: openrouter
+    model_id: anthropic/claude-haiku-4.5
+    capabilities:
+      supports_json_mode: false
+      supports_temperature: true
+      supports_system: true
+    cost: runtime
+
+  "openrouter:qwen/qwen3.5-plus":
+    metadata:
+      model_reference: "alibaba_qwen35_plus"
+    provider: openrouter
+    model_id: qwen/qwen3.5-plus-02-15
     capabilities:
       supports_json_mode: false
       supports_temperature: true

--- a/src/elelem/providers/virtual-models.yaml
+++ b/src/elelem/providers/virtual-models.yaml
@@ -311,3 +311,16 @@ models:
       speed_weight: 2.0
     candidates:
       - model: "virtual:kimi-k2"
+
+  # ---------------------------------------------------------------------------
+  # Claude Sonnet 4.6 — Anthropic direct, then OpenRouter, then DeepSeek fallback
+  # ---------------------------------------------------------------------------
+  "virtual:claude-sonnet-4.6":
+    metadata:
+      model_reference: "anthropic_claude_sonnet_46"
+    timeout: 120s
+    candidates:
+      - model: "anthropic:anthropic/claude-sonnet-4.6"
+      - model: "openrouter:anthropic/claude-sonnet-4.6"
+      - model: "virtual:deepseek-v3.2"
+        priority: always_last

--- a/src/elelem/server/Dockerfile
+++ b/src/elelem/server/Dockerfile
@@ -27,7 +27,8 @@ RUN python -m venv /opt/venv && \
         psycopg2-binary \
         json-repair \
         requests \
-        google-auth
+        google-auth \
+        anthropic
 
 # Copy source code to site-packages
 # Fix permissions for non-root user in hardened image

--- a/tests/anthropic_e2e_test.py
+++ b/tests/anthropic_e2e_test.py
@@ -1,0 +1,157 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "anthropic>=0.40.0",
+#     "python-dotenv>=1.0.1",
+# ]
+# ///
+"""
+End-to-end test: Anthropic provider through Elelem.
+
+Tests the full adapter path: Elelem → AnthropicAdapter → Anthropic API.
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+# Add src to path so we can import elelem
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from elelem import Elelem
+
+
+async def test_basic_call():
+    """Test basic non-thinking call through Elelem."""
+    print("\n>>> Test: Basic call (Sonnet 4.6)")
+    e = Elelem()
+
+    response = await e.create_chat_completion(
+        model="anthropic:anthropic/claude-sonnet-4.6",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant. Be concise."},
+            {"role": "user", "content": "What is 2+2? Answer in one word."},
+        ],
+        temperature=0.0,
+    )
+
+    content = response.choices[0].message.content
+    metrics = response.elelem_metrics
+    print(f"  Content: {content}")
+    print(f"  Model: {metrics['model_used']}")
+    print(f"  Tokens: in={metrics['tokens']['input']}, out={metrics['tokens']['output']}")
+    print(f"  Cost: ${metrics['costs_usd']['total_cost_usd']:.6f}")
+    return True
+
+
+async def test_json_schema():
+    """Test JSON schema validation through Elelem."""
+    print("\n>>> Test: JSON schema validation (Sonnet 4.6)")
+    e = Elelem()
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "answer": {"type": "integer"},
+            "explanation": {"type": "string"},
+        },
+        "required": ["answer", "explanation"],
+    }
+
+    response = await e.create_chat_completion(
+        model="anthropic:anthropic/claude-sonnet-4.6",
+        messages=[
+            {"role": "user", "content": "What is 15 * 7? Return JSON with 'answer' and 'explanation'."},
+        ],
+        response_format={"type": "json_object"},
+        json_schema=schema,
+        temperature=0.0,
+    )
+
+    content = response.choices[0].message.content
+    print(f"  Content: {content}")
+    parsed = json.loads(content)
+    print(f"  Parsed: {parsed}")
+    assert parsed["answer"] == 105, f"Expected 105, got {parsed['answer']}"
+    print("  Schema validation: PASS")
+    return True
+
+
+async def test_thinking():
+    """Test extended thinking through Elelem."""
+    print("\n>>> Test: Extended thinking (Sonnet 4.6?thinking)")
+    e = Elelem()
+
+    response = await e.create_chat_completion(
+        model="anthropic:anthropic/claude-sonnet-4.6?thinking",
+        messages=[
+            {"role": "user", "content": "What is 17 * 23?"},
+        ],
+    )
+
+    content = response.choices[0].message.content
+    metrics = response.elelem_metrics
+    reasoning = metrics.get("reasoning_content")
+    print(f"  Content: {content}")
+    print(f"  Reasoning: {reasoning[:200] if reasoning else 'None'}...")
+    print(f"  Tokens: in={metrics['tokens']['input']}, out={metrics['tokens']['output']}")
+    return True
+
+
+async def test_streaming():
+    """Test streaming (internal) through Elelem."""
+    print("\n>>> Test: Streaming (Sonnet 4.6, stream=true in provider config)")
+    e = Elelem()
+
+    response = await e.create_chat_completion(
+        model="anthropic:anthropic/claude-sonnet-4.6",
+        messages=[
+            {"role": "user", "content": "Count from 1 to 5, one per line."},
+        ],
+        temperature=0.0,
+    )
+
+    content = response.choices[0].message.content
+    metrics = response.elelem_metrics
+    print(f"  Content: {content}")
+    print(f"  Tokens: in={metrics['tokens']['input']}, out={metrics['tokens']['output']}")
+    return True
+
+
+async def main():
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY not found")
+        sys.exit(1)
+
+    tests = [
+        ("Basic call", test_basic_call),
+        ("JSON schema", test_json_schema),
+        ("Thinking", test_thinking),
+        ("Streaming", test_streaming),
+    ]
+
+    results = {}
+    for name, fn in tests:
+        try:
+            ok = await fn()
+            results[name] = "PASS" if ok else "FAIL"
+        except Exception as e:
+            import traceback
+            print(f"\n  EXCEPTION: {type(e).__name__}: {e}")
+            traceback.print_exc()
+            results[name] = f"ERROR: {type(e).__name__}"
+
+    print("\n\n" + "=" * 60)
+    print("  E2E SUMMARY")
+    print("=" * 60)
+    for name, result in results.items():
+        print(f"  {result:12s}  {name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/anthropic_sanity_check.py
+++ b/tests/anthropic_sanity_check.py
@@ -1,0 +1,306 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "anthropic>=0.40.0",
+#     "python-dotenv>=1.0.1",
+# ]
+# ///
+"""
+Sanity check script for Anthropic API behavior.
+
+Validates assumptions needed for the Elelem adapter:
+1. Non-streaming response structure (content blocks, usage, stop_reason)
+2. Streaming event types and structure
+3. Extended thinking block format
+4. Error exception types
+
+Run: uv run tests/anthropic_sanity_check.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+import traceback
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import anthropic
+
+
+def pp(label, obj):
+    """Pretty-print an object with a label."""
+    print(f"\n{'='*60}")
+    print(f"  {label}")
+    print(f"{'='*60}")
+    if hasattr(obj, "model_dump"):
+        print(json.dumps(obj.model_dump(), indent=2, default=str))
+    else:
+        print(obj)
+
+
+async def test_non_streaming():
+    """Test 1: Non-streaming call — inspect Message structure."""
+    print("\n\n>>> TEST 1: Non-streaming call")
+    client = anthropic.AsyncAnthropic()
+
+    response = await client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=100,
+        messages=[{"role": "user", "content": "Say hello in exactly 5 words."}],
+    )
+
+    pp("Full response object", response)
+
+    # Key fields we need for the adapter
+    print("\n--- Key fields ---")
+    print(f"response.id          = {response.id}")
+    print(f"response.model       = {response.model}")
+    print(f"response.stop_reason = {response.stop_reason}")
+    print(f"response.type        = {response.type}")
+
+    print(f"\nresponse.usage.input_tokens  = {response.usage.input_tokens}")
+    print(f"response.usage.output_tokens = {response.usage.output_tokens}")
+
+    print(f"\nContent blocks ({len(response.content)}):")
+    for i, block in enumerate(response.content):
+        print(f"  [{i}] type={block.type}, text={repr(block.text[:100]) if hasattr(block, 'text') else 'N/A'}")
+
+    return True
+
+
+async def test_non_streaming_with_system():
+    """Test 1b: Non-streaming with system message."""
+    print("\n\n>>> TEST 1b: Non-streaming with system message")
+    client = anthropic.AsyncAnthropic()
+
+    response = await client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=100,
+        system="You are a pirate. Always respond in pirate speak.",
+        messages=[{"role": "user", "content": "Say hello in exactly 5 words."}],
+    )
+
+    print(f"Response: {response.content[0].text}")
+    print(f"stop_reason: {response.stop_reason}")
+    return True
+
+
+async def test_streaming():
+    """Test 2: Streaming call — inspect raw event types and structure."""
+    print("\n\n>>> TEST 2: Streaming call")
+    client = anthropic.AsyncAnthropic()
+
+    stream = await client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=100,
+        stream=True,
+        messages=[{"role": "user", "content": "Count from 1 to 5."}],
+    )
+
+    print("\n--- Raw streaming events ---")
+    event_count = 0
+    async for event in stream:
+        event_count += 1
+        event_type = event.type
+
+        if event_type == "message_start":
+            msg = event.message
+            print(f"  [{event_count}] message_start: id={msg.id}, model={msg.model}, usage.input_tokens={msg.usage.input_tokens}")
+
+        elif event_type == "content_block_start":
+            print(f"  [{event_count}] content_block_start: index={event.index}, type={event.content_block.type}")
+
+        elif event_type == "content_block_delta":
+            delta = event.delta
+            if delta.type == "text_delta":
+                print(f"  [{event_count}] content_block_delta[text_delta]: text={repr(delta.text[:50])}")
+            elif delta.type == "thinking_delta":
+                print(f"  [{event_count}] content_block_delta[thinking_delta]: thinking={repr(delta.thinking[:50])}")
+            elif delta.type == "signature_delta":
+                print(f"  [{event_count}] content_block_delta[signature_delta]: sig={delta.signature[:30]}...")
+            else:
+                print(f"  [{event_count}] content_block_delta[{delta.type}]: {delta}")
+
+        elif event_type == "content_block_stop":
+            print(f"  [{event_count}] content_block_stop: index={event.index}")
+
+        elif event_type == "message_delta":
+            print(f"  [{event_count}] message_delta: stop_reason={event.delta.stop_reason}, usage.output_tokens={event.usage.output_tokens}")
+
+        elif event_type == "message_stop":
+            print(f"  [{event_count}] message_stop")
+
+        elif event_type == "ping":
+            print(f"  [{event_count}] ping")
+
+        else:
+            print(f"  [{event_count}] UNKNOWN: {event_type} — {event}")
+
+    print(f"\nTotal events: {event_count}")
+    return True
+
+
+async def test_thinking():
+    """Test 3: Extended thinking — verify thinking block format."""
+    print("\n\n>>> TEST 3: Extended thinking (Haiku 4.5)")
+    client = anthropic.AsyncAnthropic()
+
+    response = await client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=8000,
+        thinking={"type": "enabled", "budget_tokens": 5000},
+        messages=[{"role": "user", "content": "What is 17 * 23?"}],
+    )
+
+    print(f"\nContent blocks ({len(response.content)}):")
+    for i, block in enumerate(response.content):
+        if block.type == "thinking":
+            print(f"  [{i}] type=thinking, thinking={repr(block.thinking[:200])}...")
+            if hasattr(block, "signature"):
+                print(f"       signature={block.signature[:30]}..." if block.signature else "       signature=None")
+        elif block.type == "text":
+            print(f"  [{i}] type=text, text={repr(block.text[:200])}")
+        else:
+            print(f"  [{i}] type={block.type}")
+
+    print(f"\nUsage: input={response.usage.input_tokens}, output={response.usage.output_tokens}")
+    # Check if there's a separate thinking token count
+    usage_dict = response.usage.model_dump() if hasattr(response.usage, "model_dump") else vars(response.usage)
+    print(f"Full usage fields: {list(usage_dict.keys())}")
+    print(f"Full usage: {json.dumps(usage_dict, default=str)}")
+
+    return True
+
+
+async def test_thinking_streaming():
+    """Test 3b: Extended thinking with streaming."""
+    print("\n\n>>> TEST 3b: Extended thinking + streaming (Haiku 4.5)")
+    client = anthropic.AsyncAnthropic()
+
+    stream = await client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=8000,
+        stream=True,
+        thinking={"type": "enabled", "budget_tokens": 5000},
+        messages=[{"role": "user", "content": "What is 17 * 23?"}],
+    )
+
+    print("\n--- Streaming events with thinking ---")
+    event_count = 0
+    async for event in stream:
+        event_count += 1
+        event_type = event.type
+
+        if event_type == "message_start":
+            msg = event.message
+            print(f"  [{event_count}] message_start: id={msg.id}, input_tokens={msg.usage.input_tokens}")
+        elif event_type == "content_block_start":
+            print(f"  [{event_count}] content_block_start: index={event.index}, type={event.content_block.type}")
+        elif event_type == "content_block_delta":
+            delta = event.delta
+            if delta.type == "thinking_delta":
+                text = delta.thinking[:80] if len(delta.thinking) > 80 else delta.thinking
+                print(f"  [{event_count}] thinking_delta: {repr(text)}")
+            elif delta.type == "text_delta":
+                print(f"  [{event_count}] text_delta: {repr(delta.text[:80])}")
+            elif delta.type == "signature_delta":
+                print(f"  [{event_count}] signature_delta: (skipped)")
+            else:
+                print(f"  [{event_count}] {delta.type}")
+        elif event_type == "message_delta":
+            print(f"  [{event_count}] message_delta: stop_reason={event.delta.stop_reason}, output_tokens={event.usage.output_tokens}")
+        elif event_type in ("content_block_stop", "message_stop", "ping"):
+            print(f"  [{event_count}] {event_type}")
+        else:
+            print(f"  [{event_count}] UNKNOWN: {event_type}")
+
+    print(f"\nTotal events: {event_count}")
+    return True
+
+
+async def test_errors():
+    """Test 4: Error cases — verify exception types."""
+    print("\n\n>>> TEST 4: Error cases")
+
+    # 4a: Bad API key
+    print("\n--- 4a: Bad API key ---")
+    try:
+        bad_client = anthropic.AsyncAnthropic(api_key="sk-bad-key-12345")
+        await bad_client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+    except Exception as e:
+        print(f"  Exception type: {type(e).__module__}.{type(e).__name__}")
+        print(f"  Status code: {getattr(e, 'status_code', 'N/A')}")
+        print(f"  Message: {str(e)[:150]}")
+
+    # 4b: Bad model name
+    print("\n--- 4b: Bad model name ---")
+    try:
+        client = anthropic.AsyncAnthropic()
+        await client.messages.create(
+            model="claude-nonexistent-model",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+    except Exception as e:
+        print(f"  Exception type: {type(e).__module__}.{type(e).__name__}")
+        print(f"  Status code: {getattr(e, 'status_code', 'N/A')}")
+        print(f"  Message: {str(e)[:150]}")
+
+    # 4c: Missing max_tokens
+    print("\n--- 4c: Missing max_tokens ---")
+    try:
+        client = anthropic.AsyncAnthropic()
+        await client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            # max_tokens intentionally omitted
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+    except Exception as e:
+        print(f"  Exception type: {type(e).__module__}.{type(e).__name__}")
+        print(f"  Message: {str(e)[:150]}")
+
+    return True
+
+
+async def main():
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY not found in environment or .env file")
+        sys.exit(1)
+    print(f"API key loaded: {api_key[:10]}...{api_key[-4:]}")
+
+    tests = [
+        ("Non-streaming", test_non_streaming),
+        ("Non-streaming with system", test_non_streaming_with_system),
+        ("Streaming", test_streaming),
+        ("Thinking", test_thinking),
+        ("Thinking + Streaming", test_thinking_streaming),
+        ("Errors", test_errors),
+    ]
+
+    results = {}
+    for name, test_fn in tests:
+        try:
+            ok = await test_fn()
+            results[name] = "PASS" if ok else "FAIL"
+        except Exception as e:
+            print(f"\n  EXCEPTION: {type(e).__name__}: {e}")
+            traceback.print_exc()
+            results[name] = f"ERROR: {type(e).__name__}"
+
+    print("\n\n" + "=" * 60)
+    print("  SUMMARY")
+    print("=" * 60)
+    for name, result in results.items():
+        print(f"  {result:12s}  {name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -74,6 +74,54 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.72.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "anyio", version = "4.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "distro", marker = "python_full_version < '3.9'" },
+    { name = "docstring-parser", marker = "python_full_version < '3.9'" },
+    { name = "httpx", marker = "python_full_version < '3.9'" },
+    { name = "jiter", version = "0.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "sniffio", marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/07/61f3ca8e69c5dcdaec31b36b79a53ea21c5b4ca5e93c7df58c71f43bf8d8/anthropic-0.72.0.tar.gz", hash = "sha256:8971fe76dcffc644f74ac3883069beb1527641115ae0d6eb8fa21c1ce4082f7a", size = 493721, upload-time = "2025-10-28T19:13:01.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/b7/160d4fb30080395b4143f1d1a4f6c646ba9105561108d2a434b606c03579/anthropic-0.72.0-py3-none-any.whl", hash = "sha256:0e9f5a7582f038cab8efbb4c959e49ef654a56bfc7ba2da51b5a7b8a84de2e4d", size = 357464, upload-time = "2025-10-28T19:13:00.215Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.84.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "anyio", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "distro", marker = "python_full_version >= '3.9'" },
+    { name = "docstring-parser", marker = "python_full_version >= '3.9'" },
+    { name = "httpx", marker = "python_full_version >= '3.9'" },
+    { name = "jiter", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pydantic", version = "2.11.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "sniffio", marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -616,10 +664,21 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "elelem"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "anthropic", version = "0.72.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "anthropic", version = "0.84.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "fastapi" },
     { name = "flask", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "flask", version = "3.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -654,6 +713,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+anthropic = [
+    { name = "anthropic", version = "0.72.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "anthropic", version = "0.84.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
 dev = [
     { name = "black", version = "24.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "black", version = "25.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -675,6 +738,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.0.0" },
+    { name = "anthropic", specifier = ">=0.72.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=22.0.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -703,7 +768,7 @@ requires-dist = [
     { name = "streamlit", specifier = ">=1.28.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.33.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["anthropic", "dev"]
 
 [[package]]
 name = "exceptiongroup"


### PR DESCRIPTION
## Summary

Add Anthropic as a native provider using an adapter pattern that translates between Anthropic's Messages API and Elelem's OpenAI-based internals.

## What's included

### Core adapter
- `AnthropicAdapter` duck-types as `AsyncOpenAI` — all existing Elelem internals (request handlers, response processing, error classification, streaming collection) work unchanged
- Message translation (OpenAI system role → Anthropic top-level system param)
- Streaming translation (Anthropic SSE events → OpenAI ChatCompletionChunk)
- Error translation (Anthropic exceptions → OpenAI exceptions)
- Extended thinking support (adaptive for Opus 4.6, manual for Sonnet/Haiku)
- Handles Anthropic's temperature/top_p mutual exclusion constraint

### Models
**Direct Anthropic** (via adapter):
- Claude Opus 4.6, Sonnet 4.6, Haiku 4.5 — each with/without thinking
- Legacy: Sonnet 4, Opus 4

**Via OpenRouter** (standard OpenAI client):
- Claude Opus 4.6, Sonnet 4.6, Haiku 4.5
- Qwen 3.5 Plus

**Virtual model:**
- `virtual:claude-sonnet-4.6` — Anthropic direct → OpenRouter → DeepSeek v3.2 fallback

### Bug fixes
- Fix benchmark store crash when `cost: runtime` (string) instead of dict (OpenRouter models)
- Enable streaming for OpenRouter provider

## Testing
- 49/49 tests pass (9 config validation + 40 faker)
- E2E tested: basic call, JSON schema, extended thinking, streaming
- Telelem tested: all models (direct + OpenRouter), reasoning vs non-reasoning verified
- Tested in production via Fable story generation (Docker)